### PR TITLE
Implement abstract factory design pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,8 @@
         "symfony/dotenv": "5.2.*",
         "symfony/flex": "^1.3.1",
         "symfony/framework-bundle": "5.2.*",
-        "symfony/yaml": "5.2.*"
-    },
-    "require-dev": {
+        "symfony/yaml": "5.2.*",
+        "webmozart/assert": "^1.10"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddab81359814b88dad27a2f6d961a375",
+    "content-hash": "a4149586d5c2981827346d7f0bc57cea",
     "packages": [
         {
             "name": "psr/cache",
@@ -2507,6 +2507,64 @@
                 }
             ],
             "time": "2021-03-06T07:59:01+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/AbstractFactory/Encoder/Encoder.php
+++ b/src/AbstractFactory/Encoder/Encoder.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory\Encoder;
+
+interface Encoder
+{
+    public function encode(string $password): string;
+}

--- a/src/AbstractFactory/Encoder/HashEncoder.php
+++ b/src/AbstractFactory/Encoder/HashEncoder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory\Encoder;
+
+final class HashEncoder implements Encoder
+{
+    private string $hash;
+
+    public function __construct(string $hash)
+    {
+        $this->hash = $hash;
+    }
+
+    public function encode(string $password): string
+    {
+        return hash($this->hash, $password, false);
+    }
+}

--- a/src/AbstractFactory/Encoder/StringRotationEncoder.php
+++ b/src/AbstractFactory/Encoder/StringRotationEncoder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory\Encoder;
+
+final class StringRotationEncoder implements Encoder
+{
+    public function encode(string $password): string
+    {
+        return str_rot13($password);
+    }
+}

--- a/src/AbstractFactory/EncoderFactory.php
+++ b/src/AbstractFactory/EncoderFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory;
+
+use App\AbstractFactory\Encoder\Encoder;
+use App\AbstractFactory\Factory\Md5EncoderFactory;
+use App\AbstractFactory\Factory\Sha256EncoderFactory;
+use App\AbstractFactory\Factory\StringRotationEncoderFactory;
+use InvalidArgumentException;
+
+abstract class EncoderFactory
+{
+    abstract public function getEncoder(): Encoder;
+
+    public static function getEncoderFactory(EncodingType $encodingType): self
+    {
+        return match ($encodingType->toString()) {
+            EncodingType::ROT13 => new StringRotationEncoderFactory(),
+            EncodingType::SHA256 => new Sha256EncoderFactory(),
+            EncodingType::MD5 => new Md5EncoderFactory(),
+            default => throw new InvalidArgumentException(
+                sprintf('Unsupported encoding type "%s"', $encodingType->toString())
+            ),
+        };
+    }
+}

--- a/src/AbstractFactory/EncodingType.php
+++ b/src/AbstractFactory/EncodingType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory;
+
+use Webmozart\Assert\Assert;
+
+final class EncodingType
+{
+    public const MD5 = 'MD5';
+    public const SHA256 = 'SHA256';
+    public const ROT13 = 'ROT13';
+
+    private string $encodingType;
+
+    private function __construct(string $encodingType)
+    {
+        Assert::oneOf($encodingType, [self::MD5, self::SHA256, self::ROT13]);
+
+        $this->encodingType = $encodingType;
+    }
+
+    public static function fromString(string $encodingType)
+    {
+        return new self($encodingType);
+    }
+
+    public function toString(): string
+    {
+        return $this->encodingType;
+    }
+}

--- a/src/AbstractFactory/EncodingType.php
+++ b/src/AbstractFactory/EncodingType.php
@@ -16,7 +16,7 @@ final class EncodingType
 
     private function __construct(string $encodingType)
     {
-        Assert::oneOf($encodingType, [self::MD5, self::SHA256, self::ROT13]);
+        Assert::oneOf($encodingType, self::all());
 
         $this->encodingType = $encodingType;
     }
@@ -24,6 +24,12 @@ final class EncodingType
     public static function fromString(string $encodingType)
     {
         return new self($encodingType);
+    }
+
+    /** @returns string[] */
+    public static function all(): array
+    {
+        return [self::MD5, self::SHA256, self::ROT13];
     }
 
     public function toString(): string

--- a/src/AbstractFactory/Factory/Md5EncoderFactory.php
+++ b/src/AbstractFactory/Factory/Md5EncoderFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory\Factory;
+
+use App\AbstractFactory\Encoder\Encoder;
+use App\AbstractFactory\Encoder\HashEncoder;
+use App\AbstractFactory\EncoderFactory;
+
+final class Md5EncoderFactory extends EncoderFactory
+{
+    public function getEncoder(): Encoder
+    {
+        return new HashEncoder('md5');
+    }
+}

--- a/src/AbstractFactory/Factory/Sha256EncoderFactory.php
+++ b/src/AbstractFactory/Factory/Sha256EncoderFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory\Factory;
+
+use App\AbstractFactory\Encoder\Encoder;
+use App\AbstractFactory\Encoder\HashEncoder;
+use App\AbstractFactory\EncoderFactory;
+
+final class Sha256EncoderFactory extends EncoderFactory
+{
+    public function getEncoder(): Encoder
+    {
+        return new HashEncoder('sha256');
+    }
+}

--- a/src/AbstractFactory/Factory/StringRotationEncoderFactory.php
+++ b/src/AbstractFactory/Factory/StringRotationEncoderFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AbstractFactory\Factory;
+
+use App\AbstractFactory\Encoder\Encoder;
+use App\AbstractFactory\Encoder\StringRotationEncoder;
+use App\AbstractFactory\EncoderFactory;
+
+final class StringRotationEncoderFactory extends EncoderFactory
+{
+    public function getEncoder(): Encoder
+    {
+        return new StringRotationEncoder();
+    }
+}

--- a/src/Command/EncodeCommand.php
+++ b/src/Command/EncodeCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\AbstractFactory\EncoderFactory;
+use App\AbstractFactory\EncodingType;
+use InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class EncodeCommand extends Command
+{
+    protected static $defaultName = 'app:encode:password';
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Encodes a password')
+            ->setHelp('This command demos the use of the abstract factory design pattern')
+            ->addArgument('password', InputArgument::REQUIRED, 'Please enter a password you\'d like to encode')
+            ->addArgument('encoding', InputArgument::OPTIONAL, 'How would you like to encode the password?', 'SHA256')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $encoding = $input->getArgument('encoding');
+        if (!is_string($encoding)) {
+            throw new InvalidArgumentException('Encoding must be a string');
+        }
+        $encodingType = EncodingType::fromString($encoding);
+
+        $password = $input->getArgument('password');
+        if (!is_string($password)) {
+            throw new InvalidArgumentException('Password must be a string');
+        }
+
+        $encoder = EncoderFactory::getEncoderFactory($encodingType);
+        $encodedPassword = $encoder->getEncoder()->encode($password);
+
+        $output->writeln(sprintf('-- Encoding password with %s encoding --', $encodingType->toString()));
+        $output->writeln($encodedPassword);
+        $output->writeln('-- End of encoded password --');
+
+        return Command::SUCCESS;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -140,5 +140,8 @@
     },
     "symfony/yaml": {
         "version": "v5.2.5"
+    },
+    "webmozart/assert": {
+        "version": "1.10.0"
     }
 }


### PR DESCRIPTION
This design pattern is used for delegating any implementation details for creating a specific object. In this case the `Md5EncoderFactory` and `Sha256EncoderFactory` will both use the `HashEncoder` with a different configuration. However this is not visible from the 'outside' as the `EncoderFactory` abstracts such decisions away.

Based on [this example](https://codeburst.io/design-patterns-learning-abstract-factory-method-through-real-life-examples-9d0cc99ef0e8)